### PR TITLE
Bump NixOS to 21.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
                 { repo: "qmk/qmk_firmware", branch: "master" }
               ],
               nixPath: [
-                "nixpkgs=channel:nixos-21.05"
+                "nixpkgs=channel:nixos-21.11"
               ]
             };
 
@@ -48,7 +48,7 @@ jobs:
                 { repo: "qmk/qmk_firmware", branch: "master" }
               ],
               nixPath: [
-                "nixpkgs=channel:nixos-21.05"
+                "nixpkgs=channel:nixos-21.11"
               ]
             };
 


### PR DESCRIPTION
NixOS 21.05 is effectively EOL; use NixOS 21.11 in CI.