### PR TITLE
ci: Add the `finish` job to the `build` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,3 +148,19 @@ jobs:
       - name: Test 'qmk clean'
         if: ${{ always() && (steps.nix_shell.outcome == 'success') }}
         run: nix-shell ../nix-devenv-qmk/shell.nix --run 'qmk clean'
+
+  finish:
+    needs:
+      - setup
+      - test
+    runs-on: ubuntu-latest
+    if: always()
+    env:
+      ci_success: >-
+        ${{
+          (needs.setup.result == 'success')
+          && (needs.test.result == 'success')
+        }}
+    steps:
+      - name: Report CI status
+        run: $ci_success


### PR DESCRIPTION
Having a final job which summarizes the workflow result simplifies the maintenance of branch protection rules - instead of revising the list of required status check after any workflow changes, the final job may be made the only required status check.  That job could also be used later to send more useful notifications than the default GitHub emails.