### PR TITLE
Remove Nixpkgs-provided `poetry` from the environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -59,7 +59,7 @@ in
 mkShell {
   name = "qmk-firmware";
 
-  buildInputs = [ clang-tools dfu-programmer dfu-util diffutils git pythonEnv poetry niv ]
+  buildInputs = [ clang-tools dfu-programmer dfu-util diffutils git pythonEnv niv ]
     ++ lib.optional avr [
       pkgsCross.avr.buildPackages.binutils
       pkgsCross.avr.buildPackages.gcc8


### PR DESCRIPTION
The `poetry` package from the used Nixpkgs snapshot triggers the regex compatibility issue in Nix >= 2.10.0 binaries for `x86_64-darwin`: https://www.github.com/NixOS/nix/issues/4758

Remove the `poetry` package from the Nix shell environment for now (it is not really required to compile QMK, only to develop the Nix shell environment itself).

In addition, all `poetry` version earlier than 1.1.14 became effectively non-functional after a breaking change of the PyPI JSON API: https://www.github.com/python-poetry/poetry/pull/5973

Updating just the `poetry` package is not trivial (just adding it it to `pyproject.toml` does not work due to dependency version conflicts with other modules), therefore removing it seems to be the easiest solution to restore compatibility with new Nix versions while not creating any major inconvenience for QMK users.