### PR TITLE
Bump `poetry2nix` to 1.31.0

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "88ffae91c605aaafc2797f4096ca9f065152796a",
-        "sha256": "0iq9jlzz92r3ax1ymg00cn4s8c1wi3jgh1693abyyn0baq7gixrb",
+        "rev": "9deeedd086ee17ef199b67c4d8d5c81d45e6b0a5",
+        "sha256": "06psv5mc7xg31bvjpg030mwnk0sv90cj5bvgsdmcwicifpl3k3yj",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/88ffae91c605aaafc2797f4096ca9f065152796a.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/9deeedd086ee17ef199b67c4d8d5c81d45e6b0a5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -29,17 +29,6 @@ let
   pythonEnv = poetry2nix.mkPoetryEnv {
     projectDir = ./nix;
     overrides = poetry2nix.overrides.withDefaults (self: super: {
-      jsonschema =
-        if lib.versionAtLeast super.jsonschema.version "4.6.0"
-        then
-          super.jsonschema.overridePythonAttrs
-            (old: {
-              nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
-                self.hatchling
-                self.hatch-vcs
-              ];
-            })
-        else super.jsonschema;
       pillow = super.pillow.overridePythonAttrs(old: {
         # Use preConfigure from nixpkgs to fix library detection issues and
         # impurities which can break the build process; this also requires


### PR DESCRIPTION
The updated version contains some required fixes:
- `jsonschema` build system (so the local override can be removed):
    https://www.github.com/nix-community/poetry2nix/pull/663
    https://www.github.com/nix-community/poetry2nix/pull/670
- `setuptools_scm` → `typing-extensions` infinite recursion:
    https://www.github.com/nix-community/poetry2nix/pull/673