### PR TITLE
Bump `poetry2nix` to the most recent version

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "9deeedd086ee17ef199b67c4d8d5c81d45e6b0a5",
-        "sha256": "06psv5mc7xg31bvjpg030mwnk0sv90cj5bvgsdmcwicifpl3k3yj",
+        "rev": "75dc1a401fba508c4ed42e34d04a03c682a11f2f",
+        "sha256": "0p1i954brrgrqvv5345k92r2cf2dqj2y58gh5d7rnx0zpypbny80",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/9deeedd086ee17ef199b67c4d8d5c81d45e6b0a5.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/75dc1a401fba508c4ed42e34d04a03c682a11f2f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -29,9 +29,6 @@ let
   pythonEnv = poetry2nix.mkPoetryEnv {
     projectDir = ./nix;
     overrides = poetry2nix.overrides.withDefaults (self: super: {
-      pkgutil-resolve-name = super.pkgutil-resolve-name.overridePythonAttrs(old: {
-        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [self.flit-core];
-      });
       pillow = super.pillow.overridePythonAttrs(old: {
         # Use preConfigure from nixpkgs to fix library detection issues and
         # impurities which can break the build process; this also requires


### PR DESCRIPTION
The updated `poetry2nix` includes the [`pkgutil-resolve-name` build system update](https://github.com/nix-community/poetry2nix/pull/694), so the local override for `pkgutil-resolve-name` can be removed.