### PR TITLE
Fix cache handling in `envrc`

### DIFF
--- a/envrc
+++ b/envrc
@@ -8,4 +8,8 @@
 # Note that this file itself is **not** named `.envrc`, because it should not
 # be used as a direnv for `nix-devenv-qmk` itself.
 
-use nix
+# Break NIX_PATH on purpose to avoid duplicate cache entries in `.direnv/`
+# (normally `use nix` creates a new entry there after any nixpkgs update, but
+# with the locked nixpkgs version used by `shell.nix` this is not actually
+# required).
+NIX_PATH=nixpkgs=/dev/null use nix

--- a/envrc
+++ b/envrc
@@ -8,6 +8,10 @@
 # Note that this file itself is **not** named `.envrc`, because it should not
 # be used as a direnv for `nix-devenv-qmk` itself.
 
+# All files used by `shell.nix` must be listed explicitly to trigger the
+# environment rebuild properly (there is no autodetection for imported files).
+nix_direnv_watch_file nix/poetry.lock nix/pyproject.toml nix/sources.json nix/sources.nix
+
 # Break NIX_PATH on purpose to avoid duplicate cache entries in `.direnv/`
 # (normally `use nix` creates a new entry there after any nixpkgs update, but
 # with the locked nixpkgs version used by `shell.nix` this is not actually


### PR DESCRIPTION
Fix several problems in `envrc`:
1. Any system update which changed the `nixpkgs` version available in `NIX_PATH` resulted in a rebuild of the `shell.nix` environment; however, with the `shell.nix` style used in this project such rebuilds are not needed (the version of `nixpkgs` used by `shell.nix` is locked and does not depend on what is available in `NIX_PATH`). Disable that feature by specifying a nonexistent `nixpkgs` in `NIX_PATH` on purpose.
2. Updating `nix/poetry.lock` and other files in `nix/` did not trigger a rebuild of the `shell.nix` environment even when such rebuild was required. Fix this by invoking `nix_direnv_watch_file` with the explicit list of all files used by `shell.nix`.