### PR TITLE
Bump `poetry2nix` to the most recent version

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "75dc1a401fba508c4ed42e34d04a03c682a11f2f",
-        "sha256": "0p1i954brrgrqvv5345k92r2cf2dqj2y58gh5d7rnx0zpypbny80",
+        "rev": "11c0df8e348c0f169cd73a2e3d63f65c92baf666",
+        "sha256": "0i3wbp2p0x6bpj07sqpvkbx4lvjm0irvpmv2bjqx8k02mpjm7dg2",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/75dc1a401fba508c4ed42e34d04a03c682a11f2f.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/11c0df8e348c0f169cd73a2e3d63f65c92baf666.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -49,15 +49,6 @@ let
   pythonEnv = poetry2nix.mkPoetryEnv {
     projectDir = ./nix;
     overrides = poetry2nix.overrides.withDefaults (self: super: {
-      jsonschema =
-        if lib.versionAtLeast super.jsonschema.version "4.11.0"
-        then
-          super.jsonschema.overridePythonAttrs (old: {
-            nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-              self.hatch-fancy-pypi-readme
-            ];
-          })
-        else super.jsonschema;
       pillow = super.pillow.overridePythonAttrs(old: {
         # Use preConfigure from nixpkgs to fix library detection issues and
         # impurities which can break the build process; this also requires

--- a/shell.nix
+++ b/shell.nix
@@ -49,15 +49,6 @@ let
   pythonEnv = poetry2nix.mkPoetryEnv {
     projectDir = ./nix;
     overrides = poetry2nix.overrides.withDefaults (self: super: {
-      dotty-dict =
-        if lib.versionAtLeast super.dotty-dict.version "1.3.1"
-        then
-          super.dotty-dict.overridePythonAttrs (old: {
-            nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-              self.poetry-core
-            ];
-          })
-        else super.dotty-dict;
       jsonschema =
         if lib.versionAtLeast super.jsonschema.version "4.11.0"
         then


### PR DESCRIPTION
The updated poetry2nix includes the required build system updates for [`jsonschema` >= 4.11.0](https://github.com/nix-community/poetry2nix/pull/699) and [`dotty-dict` >= 1.3.1](https://github.com/nix-community/poetry2nix/pull/700), therefore local overrides for those packages can be removed.