### PR TITLE
ci: Test `qmk doctor`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,13 @@ jobs:
       - name: Update submodules
         run: make git-submodule
 
+      - name: Configure the 'upstream' remote
+        run: git remote add upstream https://github.com/qmk/qmk_firmware
+
+      - name: Configure the udev rules
+        if: ${{ runner.os == 'Linux' }}
+        run: sudo install -o root -g root -m 0644 util/udev/50-qmk.rules /etc/udev/rules.d/
+
       - name: Build the Nix shell environment
         id: nix_shell
         run: nix-shell ../nix-devenv-qmk/shell.nix --show-trace --run 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,10 @@ jobs:
         id: nix_shell
         run: nix-shell ../nix-devenv-qmk/shell.nix --show-trace --run 'true'
 
+      - name: Test 'qmk doctor'
+        if: ${{ always() && (steps.nix_shell.outcome == 'success') }}
+        run: nix-shell ../nix-devenv-qmk/shell.nix --run 'qmk doctor'
+
       - name: Test AVR build using 'make'
         if: ${{ always() && (steps.nix_shell.outcome == 'success') }}
         run: nix-shell ../nix-devenv-qmk/shell.nix --run 'make planck/rev5:default'


### PR DESCRIPTION
Check that `qmk doctor` completes without warnings (if there are warnings, the test will fail).  This requires some extra setup before the test (add the `upstream` remote, and install the udev rules if running on Linux).