### PR TITLE
Fix `qmk setup` to run `qmk doctor` properly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,10 @@ jobs:
         if: ${{ always() && (steps.nix_shell.outcome == 'success') }}
         run: nix-shell ../nix-devenv-qmk/shell.nix --run 'qmk doctor'
 
+      - name: Test 'qmk setup'
+        if: ${{ always() && (steps.nix_shell.outcome == 'success') }}
+        run: nix-shell ../nix-devenv-qmk/shell.nix --run 'qmk setup'
+
       - name: Test AVR build using 'make'
         if: ${{ always() && (steps.nix_shell.outcome == 'success') }}
         run: nix-shell ../nix-devenv-qmk/shell.nix --run 'make planck/rev5:default'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
 
     defaults:
       run:
+        shell: bash
         working-directory: qmk_firmware
 
     runs-on: ${{ matrix.os }}
@@ -134,7 +135,12 @@ jobs:
 
       - name: Test 'qmk setup'
         if: ${{ always() && (steps.nix_shell.outcome == 'success') }}
-        run: nix-shell ../nix-devenv-qmk/shell.nix --run 'qmk setup'
+        run: |
+          # Test 'qmk setup'
+          # 'qmk setup' does not return the exit code of 'qmk doctor',
+          # therefore grepping the text output is needed.
+          nix-shell ../nix-devenv-qmk/shell.nix --run 'qmk setup' 2>&1 | tee qmk-setup.log
+          grep -q "QMK is ready to go" qmk-setup.log
 
       - name: Test AVR build using 'make'
         if: ${{ always() && (steps.nix_shell.outcome == 'success') }}

--- a/shell.nix
+++ b/shell.nix
@@ -61,6 +61,18 @@ let
         # Allow QMK CLI to run "qmk" as a subprocess (the wrapper changes
         # $PATH and breaks these invocations).
         dontWrapPythonPrograms = true;
+
+        # Fix "qmk setup" to use the Python interpreter from the environment
+        # when invoking "qmk doctor" (sys.executable gets its value from
+        # $NIX_PYTHONEXECUTABLE, which is set by the "qmk" wrapper from the
+        # Python environment, so "qmk doctor" then runs with the proper
+        # $NIX_PYTHONPATH too, because sys.executable actually points to
+        # another wrapper from the same Python environment).
+        postPatch = ''
+          substituteInPlace qmk_cli/subcommands/setup.py \
+            --replace "[Path(sys.argv[0]).as_posix()" \
+              "[Path(sys.executable).as_posix(), Path(sys.argv[0]).as_posix()"
+        '';
       });
     });
   };


### PR DESCRIPTION
The last step of `qmk setup` is running `qmk doctor` to check for any problems in the resulting configuration (on non-Nix systems this step actually handles installation of dependencies).  However, the Python code was trying to use `sys.argv[0]` to invoke the same `qmk` script as itself, and this did not work in Nix, because `sys.argv[0]` points to the actual entry point script instead of the wrapper created by `mkPoetryEnv`, therefore a proper Python module path was not set.

Explicitly invoking the interpreter from `sys.executable` fixes the problem, because in Nix `sys.executable` is set from the Nix-specific `NIX_PYTHONEXECUTABLE` environment variable, which is set in the `qmk` wrapper from the environment created by `mkPoetryEnv`, and the path in `sys.executable` points to the `python` wrapper from the same environment, which sets `NIX_PYTHONPATH` correctly, therefore the invoked interpreter used the proper Python module path, and `qmk doctor` can run successfully.

Also add a CI test to make sure that `qmk setup` actually works and runs to completion.