### PR TITLE
ci: Fix `make git-submodule`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,9 +115,6 @@ jobs:
           ref: ${{ matrix.source.branch }}
           submodules: recursive
 
-      - name: Update submodules
-        run: make git-submodule
-
       - name: Configure the 'upstream' remote
         run: git remote add upstream https://github.com/qmk/qmk_firmware
 
@@ -128,6 +125,9 @@ jobs:
       - name: Build the Nix shell environment
         id: nix_shell
         run: nix-shell ../nix-devenv-qmk/shell.nix --show-trace --run 'true'
+
+      - name: Update submodules
+        run: nix-shell ../nix-devenv-qmk/shell.nix --run 'make git-submodule'
 
       - name: Test 'qmk doctor'
         if: ${{ always() && (steps.nix_shell.outcome == 'success') }}


### PR DESCRIPTION
QMK now implements `make git-submodule` using the `qmk git-submodule` CLI command (qmk/qmk_firmware#19479).  Move the “Update submodules” step after the “Build the Nix shell environment” step, so that the QMK CLI is available, and run `make git-submodule` through `nix-shell`.