### PR TITLE
Bump `nixpkgs` and `poetry2nix`

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d373d5af960504dd60c3d06c65e553b36ef29d8",
-        "sha256": "141w8i3fi96a827cr44jydzwajq2mlhb88878yw1hx3052cblqvs",
+        "rev": "5ad9903c16126a7d949101687af0aa589b1d7d3d",
+        "sha256": "1i0nvgzzadbl29hzs5n4qbc0nnw69nh79b0kq3g7zi1926rczlqn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0d373d5af960504dd60c3d06c65e553b36ef29d8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5ad9903c16126a7d949101687af0aa589b1d7d3d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "e1ccedce9b4f58422aa6588843c2995c74d796fd",
-        "sha256": "1pyz1pblb621bsig85ir5rkc0wib0h07dbdcw712szgnwja25j42",
+        "rev": "e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d",
+        "sha256": "0zz3qzp2b5i9gw4yfxfrq07iadcdadackph12h02w19bb3535rm6",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/e1ccedce9b4f58422aa6588843c2995c74d796fd.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -36,14 +36,6 @@ let
         propagatedBuildInputs = (old.buildInputs or []) ++ pkgs.python3.pkgs.pillow.propagatedBuildInputs;
         buildInputs = (old.buildInputs or []) ++ pkgs.python3.pkgs.pillow.buildInputs;
         preConfigure = (old.preConfigure or "") + pkgs.python3.pkgs.pillow.preConfigure;
-
-        # https://github.com/nix-community/poetry2nix/issues/1139
-        patches = (old.patches or []) ++ lib.optionals (old.version == "9.5.0") [
-          (pkgs.fetchpatch  {
-            url = "https://github.com/python-pillow/Pillow/commit/0ec0a89ead648793812e11739e2a5d70738c6be5.diff";
-            sha256 = "sha256-rZfk+OXZU6xBpoumIW30E80gRsox/Goa3hMDxBUkTY0=";
-          })
-        ];
       });
       qmk = super.qmk.overridePythonAttrs(old: {
         # Allow QMK CLI to run "qmk" as a subprocess (the wrapper changes

--- a/shell.nix
+++ b/shell.nix
@@ -29,20 +29,6 @@ let
   pythonEnv = poetry2nix.mkPoetryEnv {
     projectDir = ./nix;
     overrides = poetry2nix.overrides.withDefaults (self: super: {
-      jsonschema = super.jsonschema.overridePythonAttrs(old: {
-        postPatch = ''
-          sed -i "/Topic/d" pyproject.toml
-        '';
-      });
-      jsonschema-specifications = super.jsonschema-specifications.overridePythonAttrs(old: {
-        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-          self.hatchling
-          self.hatch-vcs
-        ];
-        postPatch = ''
-          sed -i "/Topic/d" pyproject.toml
-        '';
-      });
       pillow = super.pillow.overridePythonAttrs(old: {
         # Use preConfigure from nixpkgs to fix library detection issues and
         # impurities which can break the build process; this also requires
@@ -59,34 +45,6 @@ let
           })
         ];
       });
-      referencing = super.referencing.overridePythonAttrs(old: {
-        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-          self.hatchling
-          self.hatch-vcs
-        ];
-        postPatch = ''
-          sed -i "/Topic/d" pyproject.toml
-        '';
-      });
-      rpds-py = let
-        getCargoHash = version: {
-          "0.8.8" = "sha256-jg9oos4wqewIHe31c3DixIp6fssk742kqt4taWyOq4U=";
-        }.${version} or (
-          lib.warn "Unknown rpds-py version: '${version}'. Please update getCargoHash." lib.fakeHash
-        );
-      in
-        super.rpds-py.overridePythonAttrs(old: {
-          cargoDeps = pkgs.rustPlatform.fetchCargoTarball {
-            inherit (old) src;
-            name = "${old.pname}-${old.version}";
-            hash = getCargoHash old.version;
-          };
-          nativeBuildInputs = (old.nativeBuildInputs or []) ++ [
-            pkgs.rustPlatform.cargoSetupHook
-            pkgs.rustPlatform.maturinBuildHook
-          ];
-          buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
-        });
       qmk = super.qmk.overridePythonAttrs(old: {
         # Allow QMK CLI to run "qmk" as a subprocess (the wrapper changes
         # $PATH and breaks these invocations).


### PR DESCRIPTION
Bump `nixpkgs` to the current `nixpkgs-unstable` snapshot (2024-02-01).  This might actually avoid the need to build `avr-gcc` from source on Darwin, because the build problems were fixed upstream.

Bump `poetry2nix` to the most recent version (2024.1.1244871) to match `nixpkgs` and get updated overrides for Python packages.

Drop most local overrides for Python packages which are now included in `poetry2nix`.

Currently there are some warnings during evaluation:
```
trace: warning: `pythonForBuild` (from `python*`) has been renamed to `pythonOnBuildForHost`
trace: warning: `pythonForBuild` (from `python*`) has been renamed to `pythonOnBuildForHost`
```
These warnings are because of a change in Nixpkgs (NixOS/nixpkgs#265764) which needs some corresponding changes in `poetry2nix` (nix-community/poetry2nix#1521).