### PR TITLE
Bump `nixpkgs` and `poetry2nix`

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d",
-        "sha256": "0zz3qzp2b5i9gw4yfxfrq07iadcdadackph12h02w19bb3535rm6",
+        "rev": "921e964a8ee40538482b49500e5a08af4d9df379",
+        "sha256": "08vixgh8ylj9hdl8fii08nfjrzmyc9jr00a2gpp5w00fkvn0cc3r",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/e0b44e9e2d3aa855d1dd77b06f067cd0e0c3860d.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/921e964a8ee40538482b49500e5a08af4d9df379.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ad9903c16126a7d949101687af0aa589b1d7d3d",
-        "sha256": "1i0nvgzzadbl29hzs5n4qbc0nnw69nh79b0kq3g7zi1926rczlqn",
+        "rev": "79a13f1437e149dc7be2d1290c74d378dad60814",
+        "sha256": "10shz1jkjrzyhjc69vx50w86mk94w3b6cf00cqr7x016cf6jfll5",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5ad9903c16126a7d949101687af0aa589b1d7d3d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/79a13f1437e149dc7be2d1290c74d378dad60814.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {

--- a/shell.nix
+++ b/shell.nix
@@ -29,20 +29,6 @@ let
   pythonEnv = poetry2nix.mkPoetryEnv {
     projectDir = ./nix;
     overrides = [ poetry2nix.defaultPoetryOverrides (self: super: {
-      rpds-py = let
-        getCargoHash = version: {
-          "0.17.1" = "sha256-sFutrKLa2ISxtUN7hmw2P02nl4SM6Hn4yj1kkXrNWmI=";
-        }.${version} or (
-          lib.warn "Unknown rpds-py version: '${version}'. Please update getCargoHash." lib.fakeHash
-        );
-      in
-        super.rpds-py.overridePythonAttrs(old: {
-          cargoDeps = pkgs.rustPlatform.fetchCargoTarball {
-            inherit (old) src;
-            name = "${old.pname}-${old.version}";
-            hash = getCargoHash old.version;
-          };
-        });
       qmk = super.qmk.overridePythonAttrs(old: {
         # Allow QMK CLI to run "qmk" as a subprocess (the wrapper changes
         # $PATH and breaks these invocations).


### PR DESCRIPTION
Bump `poetry2nix` to 2024.2.443681.  This version should have the fix to avoid deprecation warnings with new `nixpkgs` versions (`pythonForBuild` had been renamed to `pythonOnBuildForHost`).

Drop the `rpds-py` 0.17.1 override which is already included in new `poetry2nix`.

Bump `nixpkgs` to the current `nixpkgs-unstable` snapshot (2024-02-05) just in case.