### PR TITLE
CI: Use `macos-14` runners to support `aarch64-darwin`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
             // Matrix for the "default" and "full" modes.
             const defaultMatrix = {
-              os: [ "ubuntu-latest", "macos-latest", "macos-14" ],
+              os: [ "ubuntu-latest", "macos-12", "macos-14" ],
               source: [
                 { repo: "qmk/qmk_firmware", branch: "master" }
               ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
                 { repo: "qmk/qmk_firmware", branch: "master" }
               ],
               nixPath: [
-                "nixpkgs=channel:nixos-21.11"
+                "nixpkgs=channel:nixos-23.11"
               ]
             };
 
@@ -48,7 +48,7 @@ jobs:
                 { repo: "qmk/qmk_firmware", branch: "master" }
               ],
               nixPath: [
-                "nixpkgs=channel:nixos-21.11"
+                "nixpkgs=channel:nixos-23.11"
               ]
             };
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
             // Matrix for the "default" and "full" modes.
             const defaultMatrix = {
-              os: [ "ubuntu-latest", "macos-latest" ],
+              os: [ "ubuntu-latest", "macos-latest", "macos-14" ],
               source: [
                 { repo: "qmk/qmk_firmware", branch: "master" }
               ],


### PR DESCRIPTION
GitHub now [has Apple M1 runners available to all plans](https://github.com/actions/runner-images/issues/9254) as `runs-on: macos-14`; use this new feature to get the Nix shell environment built for `aarch64-darwin`.

Now 3 architectures supported by Nix are tested:
- `x86_64-linux` (on `ubuntu-latest` runners)
- `x86_64-darwin` (on `macos-12` runners)
- `aarch64-darwin` (on `macos-14` runners)

Unfortunately, support for `aarch64-linux` [is still not provided by GitHub](https://github.com/actions/runner-images/issues/5631).