### PR TITLE
Bump `nixpkgs` and `poetry2nix`

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79a13f1437e149dc7be2d1290c74d378dad60814",
-        "sha256": "10shz1jkjrzyhjc69vx50w86mk94w3b6cf00cqr7x016cf6jfll5",
+        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
+        "sha256": "1m6dm144mbm56n9293m26f46bjrklknyr4q4kzvxkiv036ijma98",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/79a13f1437e149dc7be2d1290c74d378dad60814.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/98b00b6947a9214381112bdb6f89c25498db4959.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "921e964a8ee40538482b49500e5a08af4d9df379",
-        "sha256": "08vixgh8ylj9hdl8fii08nfjrzmyc9jr00a2gpp5w00fkvn0cc3r",
+        "rev": "3c92540611f42d3fb2d0d084a6c694cd6544b609",
+        "sha256": "1jfrangw0xb5b8sdkimc550p3m98zhpb1fayahnr7crg74as4qyq",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/921e964a8ee40538482b49500e5a08af4d9df379.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/3c92540611f42d3fb2d0d084a6c694cd6544b609.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Bump `nixpkgs` to the current `nixpkgs-unstable` snapshot (2024-02-23).

Bump `poetry2nix` to the most recent snapshot (the `2024.2.2230616` tag does not include the `rpds-py` 0.18.0 override).