### PR TITLE
Pin `clang-tools` major version to 11

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -52,7 +52,7 @@ in
 mkShell {
   name = "qmk-firmware";
 
-  buildInputs = [ clang-tools dfu-programmer dfu-util diffutils git pythonEnv niv ]
+  buildInputs = [ clang-tools_11 dfu-programmer dfu-util diffutils git pythonEnv niv ]
     ++ lib.optional avr [
       pkgsCross.avr.buildPackages.binutils
       pkgsCross.avr.buildPackages.gcc8


### PR DESCRIPTION
Different versions of `clang-format` produce different results, and QMK CI currently uses Debian “bullseye”, which has clang-format 11.0. Specify `clang-tools_11` instead of just `clang-tools` to get the same major version of `clang-format`.