### PR TITLE
Bump `nixpkgs` (2024-05-12) and `poetry2nix`

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
-        "sha256": "1m6dm144mbm56n9293m26f46bjrklknyr4q4kzvxkiv036ijma98",
+        "rev": "af8b9db5c00f1a8e4b83578acc578ff7d823b786",
+        "sha256": "0kd64p8i1gmgdjfdag2fvj4gfcsk0wa3h7w7j5l6b2yxr9plnhpm",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/98b00b6947a9214381112bdb6f89c25498db4959.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/af8b9db5c00f1a8e4b83578acc578ff7d823b786.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "3c92540611f42d3fb2d0d084a6c694cd6544b609",
-        "sha256": "1jfrangw0xb5b8sdkimc550p3m98zhpb1fayahnr7crg74as4qyq",
+        "rev": "291a863e866972f356967d0a270b259f46bf987f",
+        "sha256": "1mzsvkbxh5c1j82gsghfa3gc0amnsajygbw7n6wxn9mg48j5y45x",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/3c92540611f42d3fb2d0d084a6c694cd6544b609.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/291a863e866972f356967d0a270b259f46bf987f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -52,7 +52,7 @@ in
 mkShell {
   name = "qmk-firmware";
 
-  buildInputs = [ clang-tools_11 dfu-programmer dfu-util diffutils git pythonEnv niv ]
+  buildInputs = [ clang-tools_14 dfu-programmer dfu-util diffutils git pythonEnv niv ]
     ++ lib.optional avr [
       pkgsCross.avr.buildPackages.binutils
       pkgsCross.avr.buildPackages.gcc8


### PR DESCRIPTION
Bump `nixpkgs` to the current `nixpkgs-unstable` snapshot (2024-05-12).  In particular, the updated `nixpkgs` snapshot should have updated `avrdude` with support for `libserialport` and `hidapi`, which is required for some programmers.

Unfortunately, the new `nixpkgs` version no longer includes the `clang-tools_11` package, therefore it had been replaced with `clang-tools_14` (that major version is the default for Debian bookworm and Ubuntu 22.04, and is also present in Ubuntu 24.04).  Because of that change the output of `qmk format-c` might no longer match the output generated by QMK CI (which still uses Debian bullseye at the moment).

Bump poetry2nix to the most recent version (2024.5.939250) to match nixpkgs and get updated overrides for Python packages.