### PR TITLE
Switch back to `clang-tools` 11

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,6 +23,18 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/af8b9db5c00f1a8e4b83578acc578ff7d823b786.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "nixpkgs-clang-format": {
+        "branch": "nixpkgs-unstable",
+        "description": "Nix Packages collection & NixOS",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
+        "sha256": "1m6dm144mbm56n9293m26f46bjrklknyr4q4kzvxkiv036ijma98",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/98b00b6947a9214381112bdb6f89c25498db4959.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "poetry2nix": {
         "branch": "master",
         "description": "Convert poetry projects to nix automagically [maintainer=@adisbladis] ",

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ let
 in
 # However, if you want to override Niv's inputs, this will let you do that.
 { pkgs ? import sources.nixpkgs { }
+, pkgs-for-clang-format ? import sources.nixpkgs-clang-format { }
 , poetry2nix ? pkgs.callPackage (import sources.poetry2nix) { }
 , avr ? true
 , arm ? true
@@ -52,7 +53,7 @@ in
 mkShell {
   name = "qmk-firmware";
 
-  buildInputs = [ clang-tools_14 dfu-programmer dfu-util diffutils git pythonEnv niv ]
+  buildInputs = [ pkgs-for-clang-format.clang-tools_11 dfu-programmer dfu-util diffutils git pythonEnv niv ]
     ++ lib.optional avr [
       pkgsCross.avr.buildPackages.binutils
       pkgsCross.avr.buildPackages.gcc8


### PR DESCRIPTION
QMK CI still uses `clang-format` version 11; using a different version results in annoying mismatches that need to be fixed when submitting PRs (otherwise the format check rejects the PR).  The `clang-tools_11` package is no longer present in recent versions of Nixpkgs, therefore an old Nixpkgs snapshot is used to get that package.