### PR TITLE
Switch `nixpkgs` to the 24.11 stable branch; bump `poetry2nix`

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "291a863e866972f356967d0a270b259f46bf987f",
-        "sha256": "1mzsvkbxh5c1j82gsghfa3gc0amnsajygbw7n6wxn9mg48j5y45x",
+        "rev": "06eb56b63de2f49ae62352b5927b9285591f982a",
+        "sha256": "1nsdzjbkdsvxv93fl4wckppkak2sagfvzna0anl1rc7yddqs2fbd",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/291a863e866972f356967d0a270b259f46bf987f.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/06eb56b63de2f49ae62352b5927b9285591f982a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixpkgs-unstable",
+        "branch": "nixpkgs-24.11-darwin",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af8b9db5c00f1a8e4b83578acc578ff7d823b786",
-        "sha256": "0kd64p8i1gmgdjfdag2fvj4gfcsk0wa3h7w7j5l6b2yxr9plnhpm",
+        "rev": "464fe85c27bd5761781a2773526ef9c1b0184dda",
+        "sha256": "0lv3r5d9ppw1a84p1qxcqv3p850v3g24z8ck1qmq18jsn1inccza",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/af8b9db5c00f1a8e4b83578acc578ff7d823b786.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/464fe85c27bd5761781a2773526ef9c1b0184dda.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-clang-format": {


### PR DESCRIPTION
Switch `nixpkgs` to the 24.11 stable branch (using the `nixpkgs-24.11-darwin` branch to make sure that Darwin packages are cached; that branch is usually slightly behind the corresponding NixOS branch).  The 24.11 stable branch is used because it's the last branch which still supports older macOS versions down to Sierra 10.12; the next release (and therefore the unstable branch too) would require macOS Big Sur 11 or higher.

Bump `poetry2nix` to the latest tagged release (2024.12.2551210).